### PR TITLE
Correct bounds for VOC and NOx indices

### DIFF
--- a/adafruit_sen6x.py
+++ b/adafruit_sen6x.py
@@ -562,8 +562,8 @@ class SEN66(SEN6x):  # noqa: PLR0904
                 - pm10: PM10 concentration (µg/m³) or None if unknown
                 - humidity: Relative humidity (%) or None if unknown
                 - temperature: Temperature (°C) or None if unknown
-                - voc_index: VOC index (0.1-50.0) or None if unknown
-                - nox_index: NOx index (0.1-50.0) or None if unknown
+                - voc_index: VOC index (1.0-500.0) or None if unknown
+                - nox_index: NOx index (1.0-500.0) or None if unknown
                 - co2: CO2 concentration (ppm) or None if unknown
 
         Raises:
@@ -1107,13 +1107,13 @@ class SEN66(SEN6x):  # noqa: PLR0904
 
     @property
     def voc_index(self) -> Optional[float]:
-        """VOC index (0.1-50.0)"""
+        """VOC index (1.0-500.0)"""
         self.all_measurements()
         return self._measurement_data["voc_index"] if self._measurement_data else None
 
     @property
     def nox_index(self) -> Optional[float]:
-        """NOx index (0.1-50.0)"""
+        """NOx index (1.0-500.0)"""
         self.all_measurements()
         return self._measurement_data["nox_index"] if self._measurement_data else None
 


### PR DESCRIPTION
Per the datasheet, both the VOC and NOx indices can measure between "1" and "500" (see page 7). The register that contains each respective index is scaled by a factor of 10, which is already handled by this driver (so the value can be between 1.0 and 500.0 in 0.1 unit increments--see for example table 33). I noticed that the [0.1, 50.0] bound was incorrect while using the sensor, as I was getting higher readings. I believe that my interpretation of the datasheet as in this PR is correct, but I welcome your review. Thank you for writing this driver; your libraries are consistently well-written and easy to use, and I hope this is helpful!